### PR TITLE
fix: latest verion in curl

### DIFF
--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -809,7 +809,7 @@ systemctl enable caddy
 log "Starting mithlond app setup..."
 
 # log "Downloading Mithlond binary version $LATEST_RELEASE..."
-curl -fsSL "https://github.com/mbvlabs/mithlond-ce/releases/download/{$LATEST_RELEASE}/mithlond-linux-amd64" -o mithlond-linux-amd64
+curl -fsSL "https://github.com/mbvlabs/mithlond-ce/releases/download/${LATEST_RELEASE}/mithlond-linux-amd64" -o mithlond-linux-amd64
 
 mkdir -p "$INSTALL_DIR"
 mkdir -p "$CONFIG_DIR"


### PR DESCRIPTION
corretly use the env variable to pull latest version of mithlond